### PR TITLE
Address some issues of the example apps

### DIFF
--- a/archApp/Makefile
+++ b/archApp/Makefile
@@ -6,6 +6,7 @@ include $(TOP)/configure/CONFIG_PY
 
 PY += bplreport.py
 DB += applmetrics.db
+DB += bplstorage.db
 
 include $(TOP)/configure/RULES
 include $(TOP)/configure/RULES_PY

--- a/archApp/bplreport.py
+++ b/archApp/bplreport.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import time, sched, urllib2, json
+import time, sched, urllib, json
+import urllib.request # https://stackoverflow.com/questions/37042152/python-3-5-1-urllib-has-no-attribute-request
 from devsup.db import IOScanListBlock
 from devsup.hooks import initHook
 from devsup.util import StoppableThread
@@ -20,19 +21,21 @@ class BPLReport(object):
 
     def process(self):
         self.result = None
-        R = urllib2.urlopen(self.url, timeout=3)
+        R = None
         try:
+            R = urllib.request.urlopen(self.url, timeout=3)
             if R.getcode()!=200:
-                print 'Fail',R.getcode(), self.url
+                print ('Fail',R.getcode(), self.url)
                 self.result = None
                 return
             self.result = json.load(R)
         except:
-            print 'Error fetching',self.url
+            print ('Error fetching',self.url)
             import traceback
             traceback.print_exc()
         finally:
-            R.close()
+            if R is not None:
+                R.close()
             self.result_time = time.time()
         self.scan.interrupt(reason = self.result)
 
@@ -51,7 +54,7 @@ class ReportRunner(StoppableThread):
         try:
             R.process()
         except:
-            print 'Error in processing',R.url
+            print ('Error in processing',R.url)
             import traceback
             traceback.print_exc()
             R.fail()
@@ -59,15 +62,15 @@ class ReportRunner(StoppableThread):
     def run(self):
         self._S = S = sched.scheduler(time.time, self._sleep)
 
-        for R in BPLReport.reports.itervalues():
+        for R in iter(BPLReport.reports.values()):
             S.enter(0, 0, self._proc, (R,))
 
         try:
             S.run()
         except self._Done:
-            print 'BPL worker exit'
+            print ('BPL worker exit')
         except:
-            print 'Error in scheduler'
+            print ('Error in scheduler')
             import traceback
             traceback.print_exc()
 
@@ -76,13 +79,13 @@ _worker = ReportRunner()
 @initHook("AfterIocRunning")
 def _startWorker():
     _worker.start()
-    print 'BPL worker started'
+    print ('BPL worker started')
 
 @initHook("AtIocExit")
 def _stopWorker():
-    print 'BPL worker stopping'
+    print ('BPL worker stopping')
     _worker.join()
-    print 'BPL worker stopped'
+    print ('BPL worker stopped')
 
 class ReportItem(object):
     raw = True

--- a/devsupApp/src/devsup/disect.py
+++ b/devsupApp/src/devsup/disect.py
@@ -3,11 +3,6 @@
 from __future__ import print_function
 
 import sys, gc, inspect, time
-try:
-    InstanceType = None
-    from types import InstanceType
-except ImportError:
-    pass # py3
 
 class StatsDelta(object):
   """GC statistics tracking.
@@ -81,9 +76,6 @@ def gcstats():
     K = type(obj)
     if K is StatsDelta:
       continue # avoid counting ourselves
-
-    elif InstanceType is not None and K is InstanceType: # instance of an old-style class
-      K = getattr(obj, '__class__', K)
 
     # Track types as strings to avoid holding references
     K = str(K)

--- a/iocBoot/env_vars.bat
+++ b/iocBoot/env_vars.bat
@@ -1,0 +1,25 @@
+@echo off
+REM This script extracts the:
+REM     PATH to the Python install. On Windows, this is not a system path.
+REM     The value of the used Python version makefile variable. It is applied to the executable to be loaded.
+set TOP=%~dp0..
+set CONFIG_PY=%TOP%\configure\os\CONFIG_PY.Common.windows-x64
+REM https://stackoverflow.com/questions/232747/read-environment-variables-from-file-in-windows-batch-cmd-exe
+setlocal EnableDelayedExpansion
+for /F "tokens=1,2 delims==" %%i in ('type %CONFIG_PY%') do (
+    set rawtoken=%%i
+    REM rawtoken still ends with the " :" of the " := " text.
+    set token=!rawtoken:~0,-2%!
+    set rawvalue=%%j
+    REM rawvalue still begins with the " " of the " := " text.
+    set value=!rawvalue:~1%!
+    if "!token!"=="PY_VER" (
+        set PY_VER="!value!"
+    )
+    if "!token!"=="PY_LIBDIRS" (
+        REM remove the "\libs" from the end of the string
+        set PYTHON=!value:~0,-5%!
+    )
+)
+REM https://stackoverflow.com/questions/15494688/batch-script-make-setlocal-variable-accessed-by-other-batch-files
+endlocal & set PATH=%PYTHON%;C:\Windows & set PY_VER=%PY_VER%

--- a/iocBoot/iocapplmon/st.bat
+++ b/iocBoot/iocapplmon/st.bat
@@ -1,0 +1,6 @@
+@echo off
+set OLD_PATH=%PATH%
+call ..\env_vars.bat
+call dllPath.bat
+%TOP%\bin\windows-x64\softIocPy%PY_VER%.exe st.cmd
+set PATH=%OLD_PATH%

--- a/iocBoot/iocarchivemon/st.bat
+++ b/iocBoot/iocarchivemon/st.bat
@@ -1,0 +1,6 @@
+@echo off
+set OLD_PATH=%PATH%
+call ..\env_vars.bat
+call dllPath.bat
+%TOP%\bin\windows-x64\softIocPy%PY_VER%.exe st.cmd
+set PATH=%OLD_PATH%

--- a/iocBoot/iocweatherbnl/st.bat
+++ b/iocBoot/iocweatherbnl/st.bat
@@ -1,0 +1,8 @@
+@echo off
+REM requires the pymetar module installed.
+set OLD_PATH=%PATH%
+call ..\env_vars.bat
+call dllPath.bat
+%TOP%\bin\windows-x64\softIocPy%PY_VER%.exe st.cmd
+set PATH=%OLD_PATH%
+

--- a/iocBoot/iocweatherbnl/st.cmd
+++ b/iocBoot/iocweatherbnl/st.cmd
@@ -8,9 +8,9 @@ cd("$(TOP)")
 
 #epicsEnvSet("PYTHONPATH", "${TOP}/python/$(ARCH)")
 
-dbLoadRecords("db/weather.db","P=CF:Ext{KISP},LOC=KISP")
-#dbLoadRecords("db/weather.db","P=CF:Ext{KHWV},LOC=KHWV")
-dbLoadRecords("db/weather.db","P=CF:Ext{EGTK},LOC=EGTK")
+dbLoadRecords("db/weather.db","P=CF:Ext{KISP},LOC=KISP")  # Long Island MacArthur Airport
+#dbLoadRecords("db/weather.db","P=CF:Ext{KHWV},LOC=KHWV") # Brookhaven Calabro Airport
+dbLoadRecords("db/weather.db","P=CF:Ext{EGTK},LOC=EGTK")  # London Oxford Airport (Kidlington)
 
 iocInit()
 


### PR DESCRIPTION
When I open the box on a module like pyDevSup, the first thing I'm going to seek to do is run the example apps.
These do not currently work for the reasons outlined below.
This tends to give a less than ideal first impression.
In my view, the examples need maintenance and upgrade.

I deem it reasonable to assume that 64-bit Linux and Windows will be used.

For Windows use, I have written batch script(s) that extract PY_VER and PY_LIBDIRS by parsing the CONFIG_PY.Common.windows-x64 file.
	PY_VER is used for launching the IOC irrespective of which Python version has been used to build the code.
	PY_LIBDIRS is then used to find the Python install directory, in my case e.g. C:\Python313(\libs removed). This is used to provide the PATH to python.dll.
I lack the Linux/bash skill to do something similar for use there.
Users can of course edit the st.cmd file to launch the desired softIocPy%PY_VER%

In disect.py, InstanceType is imported is imported for Python2 usage.
This will fail with Python3 and the exception is caught.
The value of InstanceType is checked for None later.
However in these circumstances the value is not None but undefined, causing the application to fail.
disect.py is used by iocFPM and iocweatherbnl.
I have removed the Python2 usage altogether.

Of the 5 example apps:
	The iocapplmon module is dependant on archApp\bplreport.py which I updated to use Python 3 rather than Python 2.
	It is also dependant on the bplstorage.db. It needed to be added to the makefile.
	The module now runs (on Windows and Linux), but it cannot work because the address capp02.cs.nsls2.local:17665 is not accessible.
	I also tried arcapp01.cs.nsls2.local:17665.
	This address may have been changed, or possibly is not accessible to unauthenticated users?
	@mdavidsaver would you be able to advise about this? Thanks.

	iocarchivemon operates normally, on Windows and Linux.

	ioccaputlog requires a module '_inotify' to operate, which does not exist on Windows.
	The module operates normally on Linux.
	
	iocFPM is dependant on the iocStats and autoSave modules.
	autoSave works on Windows, but I was unable to build the iocStats module there.
	This application operates normally on Linux.

	iocweatherbnl operates normally, on Windows and Linux

